### PR TITLE
Use standard format for credentials file

### DIFF
--- a/aws-keychain
+++ b/aws-keychain
@@ -116,9 +116,9 @@ aws_keychain_format_credentials() {
   local id="$1"
   local secret="$2"
   cat <<END
-[Credentials]
-AWSAccessKeyId=$id
-AWSSecretKey=$secret
+[default]
+aws_access_key_id=$id
+aws_secret_access_key=$secret
 END
 }
 


### PR DESCRIPTION
This changes the format of the ~/.aws/credentials file to match the format used by the current aws cli tools: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files