### PR TITLE
credentials file has standard/modern format.

### DIFF
--- a/aws-keychain
+++ b/aws-keychain
@@ -116,7 +116,10 @@ aws_keychain_format_credentials() {
   local id="$1"
   local secret="$2"
   cat <<END
-[Credentials]
+[default]
+aws_access_key_id=$id
+aws_secret_access_key=$secret
+; deprecated format:
 AWSAccessKeyId=$id
 AWSSecretKey=$secret
 END


### PR DESCRIPTION
Thanks @powdahound in https://github.com/pda/aws-keychain/pull/6 for pointing out that the modern standard format at http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files wasn't being used.

I actually had this patch uncommitted; modern tools seem happy to have the old format in the same file.

Closes #6