### PR TITLE
overwrite credentials file before removing

### DIFF
--- a/aws-keychain
+++ b/aws-keychain
@@ -144,7 +144,7 @@ aws_keychain_ls() {
 
 aws_keychain_none() {
   [ $# -eq 1 ] || aws_keychain_usage "aws-keychain none"
-  rm -f $AWS_CREDENTIALS_FILE
+  rm -fP $AWS_CREDENTIALS_FILE
 }
 
 aws_keychain_rm() {


### PR DESCRIPTION
from 'rm' man page: -P Overwrite regular files before deleting them.  Files are overwritten three times, first with the byte pattern 0xff, then 0x00, and then 0xff again, before they are deleted.