### PR TITLE
v2: commands stripped to: add, ls, rm, exec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 aws-keychain
 ============
 
+The aim of `aws-keychain` is to run commands that require AWS credentials
+without ever storing those credentials unencrypted on disk. Mac OS X's keychain
+is used for storage, and credentials are passed to commands via the well known
+environment variables that all tools look for.
+
 ```
 aws-keychain    (c) 2014-2015 Paul Annesley    MIT license.
 
@@ -12,11 +17,7 @@ Manage access keys in Keychain:
   aws-keychain add <name> # (interactive prompt for key and secret)
   aws-keychain ls
   aws-keychain exec <name> <command ... >
-  aws-keychain cat <name>
   aws-keychain rm <name>
-  aws-keychain use <name>
-  aws-keychain status
-  aws-keychain none
 ```
 
 Install
@@ -38,37 +39,24 @@ ln -s $(pwd)/aws-keychain-completion.zsh /usr/local/share/zsh/site-functions/_aw
 Example
 -------
 
-```
-$ aws-keychain status
-No access key at /Users/example/.aws/credentials
-
-$ aws-keychain ls
-cat: /Users/example/.aws/aws-keychain.list: No such file or directory
-
+```sh
+# beware shell history
 $ aws-keychain add personal AKILNNK8O1KFMIZRQY1J QURSltVBG33e1qUxVhtsDw
 
-$ aws-keychain add work AKIJA9JFOPAKMH9AJPCJ LBCoZPXfQNVNRJbwN92pFQ
+$ aws-keychain add work
+Access Key ID: AKIJA9JFOPAKMH9AJPCJ
+Secret Access Key (hidden): ********
 
 $ aws-keychain ls
 personal
 work
 
 $ aws-keychain exec personal aws s3 ls
-
-$ aws-keychain use personal
-
-$ aws-keychain status
-personal: AKILNNK3OPAKMIZRQY1J
+2012-08-22 13:56:43 some-bucket-name
+2014-02-12 19:12:31 another-bucket
 
 $ aws-keychain rm work
 password has been deleted.
-
-$ aws-keychain ls
-personal
-
-$ aws-keychain none
-$ aws-keychain status
-No access key at /Users/example/.aws/credentials
 
 $ aws-keychain ls
 personal

--- a/aws-keychain
+++ b/aws-keychain
@@ -2,39 +2,28 @@
 
 ## aws-keychain    (c) 2014-2015 Paul Annesley    MIT license.
 ##
-## Store multiple AWS IAM access keys in Mac OS X keychain.
-## Check out one of them at a time into ~/.aws/credentials
+## Store multiple AWS IAM access keys in Mac OS X keychain and
+## execute commands with AWS credentials in environment.
 ##
-## Manage access keys in Keychain:
-##   aws-keychain add <name> <access_key_id> <secret_access_key>
-##   aws-keychain add <name> # (interactive prompt for key and secret)
+##   aws-keychain add <name> # (interactive prompts follow)
+##   aws-keychain add <name> <access_key_id> <secret_access_key> # (beware shell history)
 ##   aws-keychain ls
 ##   aws-keychain exec <name> <command ... >
-##   aws-keychain cat <name>
 ##   aws-keychain rm <name>
-##   aws-keychain use <name>
-##   aws-keychain status
-##   aws-keychain none
-##
-## `aws-keychain ls` is based on an unauthoritative list on disk,
-## as the `security` CLI to keychain cannot enumerate credentials.
+#
+# Note: `aws-keychain ls` is based on an unauthoritative list on disk, as the
+# `security` CLI to keychain cannot enumerate credentials.
 
 set -euo pipefail
 
-: ${AWS_CREDENTIALS_FILE="$HOME/.aws/credentials"}
 : ${AWS_CREDENTIALS_LIST="$HOME/.aws/aws-keychain.list"}
 
 main() {
   case "${1:-}" in
     add) aws_keychain_add "$@" ;;
-    cat) aws_keychain_cat "$@" ;;
-    env) aws_keychain_env "$@" ;; # deprecated for external use
     exec) aws_keychain_exec "$@" ;;
     ls) aws_keychain_ls "$@" ;;
-    none) aws_keychain_none "$@" ;;
     rm) aws_keychain_rm "$@" ;;
-    status) aws_keychain_status "$@" ;;
-    use) aws_keychain_use "$@" ;;
     *) aws_keychain_usage ;;
   esac
 }
@@ -55,42 +44,14 @@ aws_keychain_add() {
     -s "Amazon AWS" \
     -w "$secret" \
     -U
+  mkdir -p "$(dirname "$AWS_CREDENTIALS_LIST")"
   echo "$name" >> $AWS_CREDENTIALS_LIST
-}
-
-aws_keychain_env() {
-  [ $# -eq 2 ] || aws_keychain_usage "aws-keychain env"
-  local name="$2"
-  local raw="$(aws_keychain_raw "$name")"
-  local id="$(aws_keychain_extract_generic_attribute "$raw")"
-  local secret="$(aws_keychain_extract_password "$raw")"
-  if [ -z "$id" -o -z "$secret" ]; then
-    echo >&2 "No credentials for '$name':"
-    echo >&2 "$raw"
-    exit 1
-  fi
-  aws_keychain_format_env "$id" "$secret"
-}
-
-aws_keychain_format_env() {
-  local id="$1"
-  local secret="$2"
-  cat <<END
-export AWS_ACCESS_KEY_ID="$id"
-export AWS_SECRET_ACCESS_KEY="$secret"
-END
 }
 
 aws_keychain_exec() {
   [ $# -gt 2 ] || aws_keychain_usage "aws-keychain exec"
   local name="$2"
   shift 2
-  eval $($0 env "$name"); exec "$@"
-}
-
-aws_keychain_cat() {
-  [ $# -eq 2 ] || aws_keychain_usage "aws-keychain cat"
-  local name="$2"
   local raw="$(aws_keychain_raw "$name")"
   local id="$(aws_keychain_extract_generic_attribute "$raw")"
   local secret="$(aws_keychain_extract_password "$raw")"
@@ -99,7 +60,7 @@ aws_keychain_cat() {
     echo >&2 "$raw"
     exit 1
   fi
-  aws_keychain_format_credentials "$id" "$secret"
+  AWS_ACCESS_KEY_ID="$id" AWS_SECRET_ACCESS_KEY="$secret" "$@"
 }
 
 aws_keychain_raw() {
@@ -122,27 +83,9 @@ aws_keychain_extract_password() {
   echo "$raw" | awk '/^password:/ { gsub(/^"|"$/, "", $2); print $2 }'
 }
 
-aws_keychain_format_credentials() {
-  local id="$1"
-  local secret="$2"
-  cat <<END
-[default]
-aws_access_key_id=$id
-aws_secret_access_key=$secret
-; deprecated format:
-AWSAccessKeyId=$id
-AWSSecretKey=$secret
-END
-}
-
 aws_keychain_ls() {
   [ $# -eq 1 ] || aws_keychain_usage "aws-keychain ls"
   cat $AWS_CREDENTIALS_LIST | sort | uniq
-}
-
-aws_keychain_none() {
-  [ $# -eq 1 ] || aws_keychain_usage "aws-keychain none"
-  rm -fP $AWS_CREDENTIALS_FILE
 }
 
 aws_keychain_rm() {
@@ -157,46 +100,6 @@ aws_keychain_rm() {
   local tmp="${AWS_CREDENTIALS_LIST}.tmp"
   grep -vw "$name" $AWS_CREDENTIALS_LIST > $tmp
   mv $tmp $AWS_CREDENTIALS_LIST
-}
-
-aws_keychain_status() {
-  [ $# -eq 1 ] || aws_keychain_usage "aws-keychain status"
-  if [ ! -f $AWS_CREDENTIALS_FILE ]; then
-    echo "No access key at $AWS_CREDENTIALS_FILE"
-    exit 0
-  fi
-  local id="$(aws_keychain_current_access_key_id)"
-  if [ -z "$id" ]; then
-    echo "Could not extract access key ID from $AWS_CREDENTIALS_FILE"
-    exit 1
-  fi
-  local name="$(aws_keychain_find_name_by_id "$id")"
-  if [ -z "$name" ]; then
-    echo "Current key $id not found in keychain"
-    exit 1
-  fi
-  echo "$name: $id"
-}
-
-aws_keychain_current_access_key_id() {
-  cat $AWS_CREDENTIALS_FILE | awk 'BEGIN { FS="=" } /^AWSAccessKeyId/ { print $2 }'
-}
-
-aws_keychain_find_name_by_id() {
-  local secret="$1"
-  security find-generic-password \
-    -c "awsv" \
-    -D "access key" \
-    -G "$secret" \
-    -s "Amazon AWS" \
-    -g 2>&1 |
-    awk 'BEGIN { FS="=" } /^ *"acct"/ { gsub(/^"|"$/, "", $2); print $2 }'
-}
-
-aws_keychain_use() {
-  [ $# -eq 2 ] || aws_keychain_usage "aws-keychain use"
-  local name="$2"
-  aws_keychain_cat "$@" > $AWS_CREDENTIALS_FILE
 }
 
 aws_keychain_usage() {

--- a/aws-keychain-completion.zsh
+++ b/aws-keychain-completion.zsh
@@ -7,13 +7,9 @@ __subcommands() {
   local -a commands
   commands=(
   "add:add a new key to the keychain"
-  "cat:output an key in credentials file format"
-  "env:output an key as shell exports for eval"
+  "exec:excute a command with AWS key in environment"
   "ls:lists known keys"
-  "none:erase the current credentials file"
   "rm:delete a key from the keychain"
-  "status:show the key ID currently active in credentials file"
-  "use:use the named key; write to credentials file"
   )
   _describe "aws-keychain subcommands" commands
 }
@@ -29,6 +25,6 @@ fi
 
 if (( CURRENT == 3 )); then
   case "${words[2]}" in
-    cat|env|rm|use) __key_names ;;
+    rm|exec) __key_names ;;
   esac
 fi


### PR DESCRIPTION
This removes commands relating to (temporarily) storing credentials unencrypted on disk, leaving `aws-keychain exec <name> <cmd …>` as the primary mode of operation.