### PR TITLE
Add to keychain without auto-whitelisting retrieval.

### DIFF
--- a/aws-keychain
+++ b/aws-keychain
@@ -42,6 +42,7 @@ aws_keychain_add() {
     -G "$id" \
     -j "aws-keychain IAM access key" \
     -s "Amazon AWS" \
+    -T "" \
     -w "$secret" \
     -U
   mkdir -p "$(dirname "$AWS_CREDENTIALS_LIST")"


### PR DESCRIPTION
```
$ security add-generic-password   
Usage: add-generic-password [-a account] [-s service] [-w password] [options...] [-A|-T appPath] [keychain]
    …
    -T  Specify an application which may access this item (multiple -T options are allowed)
    …

By default, the application which creates an item is trusted to access its data without warning.
You can remove this default access by explicitly specifying an empty app pathname: -T ""
If no keychain is specified, the password is added to the default keychain.
```

This leads to authorization prompts when access the item:

![](http://caps.antifail.com/L9As1.png)