### PR TITLE
Separate aws-keychain.keychain from login.keychain

### DIFF
--- a/aws-keychain
+++ b/aws-keychain
@@ -24,6 +24,7 @@ main() {
     add) aws_keychain_add "$@" ;;
     exec) aws_keychain_exec "$@" ;;
     ls) aws_keychain_ls "$@" ;;
+    migrate) aws_keychain_migrate "$@" ;;
     rm) aws_keychain_rm "$@" ;;
     *) aws_keychain_usage ;;
   esac
@@ -62,6 +63,7 @@ aws_keychain_exec() {
   if [ -z "$id" -o -z "$secret" ]; then
     echo >&2 "No credentials for '$name':"
     echo >&2 "$raw"
+    echo >&2 "You may need to 'aws-keychain migrate'"
     exit 1
   fi
   AWS_ACCESS_KEY_ID="$id" AWS_SECRET_ACCESS_KEY="$secret" "$@"
@@ -91,6 +93,21 @@ aws_keychain_extract_password() {
 aws_keychain_ls() {
   [ $# -eq 1 ] || aws_keychain_usage "aws-keychain ls"
   cat $AWS_CREDENTIALS_LIST | sort | uniq
+}
+
+aws_keychain_migrate() {
+  local src=${AWS_KEYCHAIN_FILE_SRC:-"$HOME/Library/Keychains/login.keychain"}
+  local dst="$AWS_KEYCHAIN_FILE"
+  local tmp_list="$AWS_CREDENTIALS_LIST-migrate"
+  cp -- "$AWS_CREDENTIALS_LIST" "$tmp_list"
+  for name in $(aws_keychain_ls ls); do
+    if [ "$src" = "$dst" ]; then echo >&2 "Cannot migrate from $src to $dst"; exit 1; fi
+    echo "Migrating $name from '$src' to '$dst'"
+    AWS_KEYCHAIN_FILE="$src" aws-keychain exec $name \
+      bash -c "AWS_KEYCHAIN_FILE="$dst" $0 add \"$name\" \"\$AWS_ACCESS_KEY_ID\" \"\$AWS_SECRET_ACCESS_KEY\""
+    AWS_KEYCHAIN_FILE="$src" AWS_CREDENTIALS_LIST="$tmp_list" $0 rm $name
+  done
+  rm -- "$tmp_list"
 }
 
 aws_keychain_rm() {

--- a/aws-keychain
+++ b/aws-keychain
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 : ${AWS_CREDENTIALS_LIST="$HOME/.aws/aws-keychain.list"}
+: ${AWS_KEYCHAIN_FILE="$HOME/Library/Keychains/Amazon AWS.keychain"}
 
 main() {
   case "${1:-}" in
@@ -33,6 +34,7 @@ aws_keychain_add() {
   local name="$2"
   local id="${3:-}"
   local secret="${4:-}"
+  [ -e "$AWS_KEYCHAIN_FILE" ] || security create-keychain -P "$AWS_KEYCHAIN_FILE"
   [ -n "$id" ] ||  read -e -p "Access Key ID: " id
   [ -n "$secret" ] ||  read -e -s -p "Secret Access Key (hidden): " secret
   security add-generic-password \
@@ -42,9 +44,10 @@ aws_keychain_add() {
     -G "$id" \
     -j "aws-keychain IAM access key" \
     -s "Amazon AWS" \
-    -T "" \
     -w "$secret" \
-    -U
+    -U \
+    -T "" \
+    "$AWS_KEYCHAIN_FILE"
   mkdir -p "$(dirname "$AWS_CREDENTIALS_LIST")"
   echo "$name" >> $AWS_CREDENTIALS_LIST
 }
@@ -71,7 +74,8 @@ aws_keychain_raw() {
     -c "awsv" \
     -D "access key" \
     -s "Amazon AWS" \
-    -g 2>&1
+    -g \
+    "$AWS_KEYCHAIN_FILE" 2>&1
 }
 
 aws_keychain_extract_generic_attribute() {
@@ -97,7 +101,7 @@ aws_keychain_rm() {
     -c "awsv" \
     -D "access key" \
     -s "Amazon AWS" \
-    >/dev/null
+    "$AWS_KEYCHAIN_FILE" >/dev/null
   local tmp="${AWS_CREDENTIALS_LIST}.tmp"
   grep -vw "$name" $AWS_CREDENTIALS_LIST > $tmp
   mv $tmp $AWS_CREDENTIALS_LIST

--- a/aws-keychain
+++ b/aws-keychain
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 : ${AWS_CREDENTIALS_LIST="$HOME/.aws/aws-keychain.list"}
-: ${AWS_KEYCHAIN_FILE="$HOME/Library/Keychains/Amazon AWS.keychain"}
+: ${AWS_KEYCHAIN_FILE="$HOME/Library/Keychains/aws-keychain.keychain"}
 
 main() {
   case "${1:-}" in


### PR DESCRIPTION
Expands upon and closes #14 by @lox;

Uses (and auto-creates) a separate `aws-keychain.keychain` which can be overridden by `AWS_KEYCHAIN_FILE`. This keeps credentials out of the always-unlocked `login.keychain`, and allows fine-tuning of auto-lock parameters. Newly created keychains seem to default to auto-lock after 5 minutes and when sleeping.

Provides `aws-keychain migrate` to move items from the old keychain to the new one. Both source and destination can be specified in the environment (so e.g. reverse migration is possible), but the defaults are sensible and respect custom `AWS_KEYCHAIN_FILE`.

Compared to #14, `AWS_KEYCHAIN_FILE` defaults to `aws-keychain.keychain` rather than `Amazon AWS.keychain` so that the name matches the tool and contains no spaces.