### PR TITLE
Add support for new keychain extension on MacOS Siera and above:

### DIFF
--- a/aws-keychain
+++ b/aws-keychain
@@ -16,8 +16,15 @@
 
 set -euo pipefail
 
+## Siera detection: different keychain filename extension on 10.12 and above
+os_version=`sw_vers -productVersion`
+extension="keychain"
+if [ "${os_version:0:2}" == 10 -a "${os_version:3:2}" -ge 12 ] ; then
+  extension="keychain-db"
+fi
+
 : ${AWS_CREDENTIALS_LIST="$HOME/.aws/aws-keychain.list"}
-: ${AWS_KEYCHAIN_FILE="$HOME/Library/Keychains/aws-keychain.keychain"}
+: ${AWS_KEYCHAIN_FILE="$HOME/Library/Keychains/aws-keychain.$extension"}
 
 main() {
   case "${1:-}" in


### PR DESCRIPTION
With 10.12.0, the Keychain files now use an extension "keychain-db". This
patch uses sw_vers command to detect the MacOS version and decide which
extenion to use.

Testes and in active use on my MacOS 10.12.4 laptop.

Fixes #21 